### PR TITLE
Alterações Tags php / Erro SEFAZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Para a emissão correta da Nota Fiscal Eletrônica é importante ter os seguinte
 - Estado
 - CEP (utilizado como padrão o campo Tax VAT)
 
-Na pasta ```/app/design/``` possui exemplos de como deve ser a página Finalizar Compra e a amostragem dos campos no painel de controle do Magento. Mais informações de configuração você encontra no site Comunidade Magento: http://www.comunidademagento.com.br/portal/adicionando-campos-de-endereco/
+Na pasta ```/app/design/``` possui exemplos de como deve ser a página Finalizar Compra e a amostragem dos campos no painel de controle do Magento. Mais informações de configuração você encontra no site Comunidade Magento: https://www.comunidademagento.com.br/adicionando-campos-de-endereco/
 
 **Exemplo de campos na página Finalizar Compra**
 <p><img src="https://webmaniabr.com/wp-content/uploads/2015/12/img_56662bb04a8a0.png"></p>

--- a/app/code/local/WebmaniaBR/NFe/Model/Observer.php
+++ b/app/code/local/WebmaniaBR/NFe/Model/Observer.php
@@ -1,5 +1,5 @@
-<?
-require_once 'Mage/Sales/Model/Observer.php';
+<?php
+include 'Mage/Sales/Model/Observer.php';
 class WebmaniaBR_NFe_Model_Observer extends Mage_Sales_Model_Observer {
 
   static protected $_singletonFlag = false;

--- a/app/code/local/WebmaniaBR/NFe/Model/config.php
+++ b/app/code/local/WebmaniaBR/NFe/Model/config.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /* Credenciais da Aplicação */
 $consumerKey = ''; // Defina o Consumer Key da sua aplicação

--- a/app/code/local/WebmaniaBR/NFe/controllers/StandardController.php
+++ b/app/code/local/WebmaniaBR/NFe/controllers/StandardController.php
@@ -73,17 +73,23 @@ class WebmaniaBR_Nfe_StandardController extends Mage_Adminhtml_Controller_Action
       // Emissão automática de Nota Fiscal
       $notafiscal = new WebmaniaBR_NFe_Model_Observer;
       $response = $notafiscal->emitirNfe( $order, null, null, true );
+    
       $orderno = (int) $order->getIncrementId();
-      if (isset($response->error)) {
+      if (isset($response->error)){
         Mage::getSingleton('core/session')->addError("Nota Fiscal #".$orderno.': '.$response->error);
-        if ($response->log){
-          foreach ($response->log as $erros){
-            foreach ($erros as $erro) {
-              Mage::getSingleton('core/session')->addError("- ".$erro);
-            }
+      }elseif($response->status == 'reprovado'){
+        if (isset($response->log)){
+          if ($response->log->xMotivo){
+            if(isset($response->log->aProt[0]->xMotivo)){
+							$error = $response->log->aProt[0]->xMotivo;
+						}else{
+							$error = $response->log->xMotivo;
+						}
+
+            Mage::getSingleton('core/session')->addError("- ".$error);
           }
         }
-      } else {
+      }else {
 
         $setup = new Mage_Sales_Model_Resource_Setup('core_setup');
 

--- a/app/code/local/WebmaniaBR/NFe/controllers/StandardController.php
+++ b/app/code/local/WebmaniaBR/NFe/controllers/StandardController.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 class WebmaniaBR_Nfe_StandardController extends Mage_Adminhtml_Controller_Action
 {


### PR DESCRIPTION
- Removido shortcut <? e alterado para <?php. Alguns servidores estavam tendo problemas com isso.
- Removido também require_once do Observer.php, que apresentou problema em uma loja com nginx.
- Corrigido bug de leitura do erro retornado pelo SEFAZ ao emitir NFe
  ![image](https://cloud.githubusercontent.com/assets/21242891/18801072/0ea4716a-81b7-11e6-9164-3cf44d1a6788.png)
