### PR TITLE
Use include_once ao invés de include

### DIFF
--- a/1.x/app/code/local/WebmaniaBR/NFe/Model/Observer.php
+++ b/1.x/app/code/local/WebmaniaBR/NFe/Model/Observer.php
@@ -1,5 +1,5 @@
 <?php
-include 'Mage/Sales/Model/Observer.php';
+include_once 'Mage/Sales/Model/Observer.php';
 class WebmaniaBR_NFe_Model_Observer extends Mage_Sales_Model_Observer {
 
   static protected $_singletonFlag = false;


### PR DESCRIPTION
Isso evita o erro "Fatal error: Cannot redeclare class Mage_Sales_Model_Observer"